### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/Config/crypto.json
+++ b/Config/crypto.json
@@ -4,7 +4,7 @@
         "encoding": "hex",
         "key": "0000000000000000"
     },
-    
+
     "cipher": {
         "method": "aes256",
         "encoding": "base64",

--- a/Config/server.json
+++ b/Config/server.json
@@ -3,9 +3,9 @@
     "//": "is any value at the 'PORT' environment variable.",
     "//": "If there is no value there, it will fallback to '8080'",
     "port": "$PORT:8080",
-    
+
     "host": "0.0.0.0",
-    
+
     "//": "It's very rare that a server manages its own TLS.",
     "//": "More commonly, vapor is served behind a proxy like nginx.",
     "securityLayer": "none"

--- a/Sources/App/Config+Setup.swift
+++ b/Sources/App/Config+Setup.swift
@@ -8,7 +8,7 @@ extension Config {
 
         try setupProviders()
     }
-    
+
     /// Configure providers
     private func setupProviders() throws {
         try addProvider(LeafProvider.Provider.self)

--- a/Sources/App/Controllers/HelloController.swift
+++ b/Sources/App/Controllers/HelloController.swift
@@ -8,14 +8,14 @@ final class HelloController: ResourceRepresentable {
     init(_ view: ViewRenderer) {
         self.view = view
     }
-    
+
     /// GET /hello
     func index(_ req: Request) throws -> ResponseRepresentable {
         return try view.make("hello", [
             "name": "World"
         ], for: req)
     }
-    
+
     /// GET /hello/:string
     func show(_ req: Request, _ string: String) throws -> ResponseRepresentable {
         return try view.make("hello", [
@@ -25,7 +25,7 @@ final class HelloController: ResourceRepresentable {
 
     /// When making a controller, it is pretty flexible in that it
     /// only expects closures, this is useful for advanced scenarios, but
-    /// most of the time, it should look almost identical to this 
+    /// most of the time, it should look almost identical to this
     /// implementation
     func makeResource() -> Resource<String> {
         return Resource(

--- a/Sources/App/Routes.swift
+++ b/Sources/App/Routes.swift
@@ -5,21 +5,21 @@ final class Routes: RouteCollection {
     init(_ view: ViewRenderer) {
         self.view = view
     }
-    
+
     func build(_ builder: RouteBuilder) throws {
         /// GET /
         builder.get { req in
             return try self.view.make("welcome")
         }
-        
+
         /// GET /hello/...
         builder.resource("hello", HelloController(view))
-        
+
         // response to requests to /info domain
         // with a description of the request
         builder.get("info") { req in
             return req.description
         }
-        
+
     }
 }

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -14,7 +14,7 @@ import App
 /// this should setup all the routes and special
 /// features of our app
 ///
-/// .run() runs the Droplet's commands, 
+/// .run() runs the Droplet's commands,
 /// if no command is given, it will default to "serve"
 let config = try Config()
 try config.setup()

--- a/Tests/AppTests/PostControllerTests.swift
+++ b/Tests/AppTests/PostControllerTests.swift
@@ -13,7 +13,7 @@ class PostControllerTests: TestCase {
     /// For these tests, we won't be spinning up a live
     /// server, and instead we'll be passing our constructed
     /// requests programmatically
-    /// this is usually an effective way to test your 
+    /// this is usually an effective way to test your
     /// application in a convenient and safe manner
     /// See RouteTests for an example of a live server test
     let controller = HelloController(TestViewRenderer())
@@ -24,7 +24,7 @@ class PostControllerTests: TestCase {
             .assertBody(contains: "hello") // path
             .assertBody(contains: "World") // default name
     }
-    
+
     func testShow() throws {
         let req = Request.makeTest(method: .get)
         try controller.show(req, "Foo").makeResponse()

--- a/Tests/AppTests/RouteTests.swift
+++ b/Tests/AppTests/RouteTests.swift
@@ -5,19 +5,19 @@ import HTTP
 @testable import Vapor
 @testable import App
 
-/// This file shows an example of testing 
+/// This file shows an example of testing
 /// routes through the Droplet.
 
 class RouteTests: TestCase {
     let drop = try! Droplet.testable()
-    
+
     func testWelcome() throws {
         try drop
             .testResponse(to: .get, at: "/")
             .assertStatus(is: .ok)
             .assertBody(contains: "It works")
     }
-    
+
     func testHello() throws {
         try drop
             .testResponse(to: .get, at: "/hello/foo")

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,3 @@ test:
     - swift build
     - swift build -c release
     - swift test
-    


### PR DESCRIPTION
I have removed trailing whitespaces because they are likely to cause unexpected differences in versioning of source codes. For example, by default, Atom editor deletes all trailing whitespaces on saving.