### PR TITLE
Update comments for consistency

### DIFF
--- a/Sources/App/app.swift
+++ b/Sources/App/app.swift
@@ -1,6 +1,6 @@
 import Vapor
 
-/// Creates an instance of Application. This is called from main.swift in the run target.
+/// Creates an instance of `Application`. This is called from `main.swift` in the run target.
 public func app(_ env: Environment) throws -> Application {
     var config = Config.default()
     var env = env

--- a/Sources/App/boot.swift
+++ b/Sources/App/boot.swift
@@ -2,5 +2,5 @@ import Vapor
 
 /// Called after your application has initialized.
 public func boot(_ app: Application) throws {
-    // your code here
+    // Your code here
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -3,18 +3,18 @@ import Vapor
 
 /// Called before your application initializes.
 public func configure(_ config: inout Config, _ env: inout Environment, _ services: inout Services) throws {
-    /// Register providers first
+    // Register providers first
     try services.register(LeafProvider())
 
-    /// Register routes to the router
+    // Register routes to the router
     let router = EngineRouter.default()
     try routes(router)
     services.register(router, as: Router.self)
     
-    /// Use Leaf for rendering views
+    // Use Leaf for rendering views
     config.prefer(LeafRenderer.self, for: ViewRenderer.self)
 
-    /// Register middleware
+    // Register middleware
     var middlewares = MiddlewareConfig() // Create _empty_ middleware config
     middlewares.use(FileMiddleware.self) // Serves files from `Public/` directory
     middlewares.use(ErrorMiddleware.self) // Catches errors and converts to HTTP response


### PR DESCRIPTION
Similar changes as to https://github.com/vapor/api-template/pull/67. There were a few minor inconsistencies which I noticed when first using the web template. Primarily, use of triple-slash where double-slash would be expected.